### PR TITLE
Support conversion to plaintext

### DIFF
--- a/src/markable/converter.c
+++ b/src/markable/converter.c
@@ -108,7 +108,7 @@ static Janet cfun_markdown_to_plaintext(int32_t argc, Janet *argv) {
     cmark_node *doc = cmark_parser_finish(parser);
 
     cmark_mem *default_mem = cmark_get_default_mem_allocator();
-    char *output = cmark_render_plaintext_with_mem(doc, options, width, default_mem);
+    char *output = cmark_render_plaintext_with_mem(doc, options, (int)width, default_mem);
 
     JanetString plaintext = janet_cstring(output);
 
@@ -182,7 +182,8 @@ static const JanetReg cfuns[] = {
      "CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES  :table-prefer-style-attributes\n"
      "CMARK_OPT_FULL_INFO_STRING               :full-info-string\n"
      "```\n\n"
-     "`width` is an unsigned integer representing the width at which to wrap "
+     "`width` is an unsigned integer representing the width at which to wrap. "
+     "Defaults to 80."
     },
     {NULL, NULL, NULL}
 };

--- a/src/markable/converter.c
+++ b/src/markable/converter.c
@@ -65,6 +65,70 @@ static Janet cfun_markdown_to_html(int32_t argc, Janet *argv) {
     return janet_wrap_string(html);
 }
 
+/* Wrap cmark-gfm's cmark_render_plaintext_with_mem().
+ *
+ * This function expects argv to contain between one and three values.
+ *
+ * The first value is the Markdown-formatted string to be converted to
+ * plaintext.
+ *
+ * The optional second value is a JanetTuple collection of JanetKeyword values
+ * that represent the options to used to parse the string. If the second
+ * parameter is not provided, the current value of markable_default_options
+ * will be used.
+ *
+ * The optional third value is a JanetTuple collection of JanetKeyword values
+ * that represent the extensions to be loaded.
+ *
+ * The return value is a wrapped JanetString value.
+ */
+static Janet cfun_markdown_to_plaintext(int32_t argc, Janet *argv) {
+    janet_arity(argc, 1, 3);
+
+    const char *input = janet_getcstring(argv, 0);
+
+    int32_t options;
+    if (argc >= 2) {
+        options = markable_extract_options(janet_getindexed(argv, 1));
+    } else {
+        options = markable_default_options;
+    }
+
+    JanetView extensions;
+    if (argc == 3) {
+        extensions = janet_getindexed(argv, 2);
+    } else {
+        extensions.items = NULL;
+        extensions.len = 0;
+    }
+
+    cmark_mem *arena_mem = cmark_get_arena_mem_allocator();
+    cmark_parser *parser = cmark_parser_new_with_mem(options, arena_mem);
+
+    for (size_t i = 0; i < (size_t)extensions.len; i++) {
+        const char *name = (const char *)janet_getkeyword(extensions.items, i);
+        cmark_syntax_extension *syntax_extension = cmark_find_syntax_extension(name);
+        if (NULL == syntax_extension) {
+            cmark_arena_reset();
+            janet_panicf("invalid extension :%s", name);
+        }
+        cmark_parser_attach_syntax_extension(parser, syntax_extension);
+    }
+
+    cmark_parser_feed(parser, input, strlen(input));
+    cmark_node *doc = cmark_parser_finish(parser);
+
+    cmark_mem *default_mem = cmark_get_default_mem_allocator();
+    char *output = cmark_render_plaintext_with_mem(doc, options, parser->syntax_extensions, default_mem);
+
+    JanetString plaintext = janet_string((uint8_t *)output, strlen(output));
+
+    default_mem->free(output);
+    cmark_arena_reset();
+
+    return janet_wrap_string(plaintext);
+}
+
 /* Enumerate the wrapped functions.
  *
  * Enumerate the wrapped functions in a struct appropriate for registration.
@@ -77,6 +141,40 @@ static const JanetReg cfuns[] = {
      "Markable converts Markdown to HTML using the cmark-gfm library. This is "
      "GitHub's implementation of the cmark Common Mark parser. It supports "
      "the GitHub-Flavored Markdown specification.\n\n"
+     "In addition to the string to convert, the user can provide `opts` and "
+     "`exts`.\n\n"
+     "`opts` is a tuple of keywords. The keywords and the cmark-gfm library "
+     "options that they map to is shown below::\n\n"
+     "```\n"
+     "cmark-gfm                                Markable\n"
+     "=======================================================================\n"
+     "CMARK_OPT_SOURCEPOS                      :sourcepos\n"
+     "CMARK_OPT_HARDBREAKS                     :hardbreaks\n"
+     "CMARK_OPT_UNSAFE                         :unsafe\n"
+     "CMARK_OPT_VALIDATE_UTF8                  :validate-utf8\n"
+     "CMARK_OPT_SMART                          :smart\n"
+     "CMARK_OPT_GITHUB_PRE_LANG                :github-pre-lang\n"
+     "CMARK_OPT_LIBERAL_HTML_TAG               :liberal-html-tag\n"
+     "CMARK_OPT_FOOTNOTES                      :footnotes\n"
+     "CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE     :strikethrough-double-tilde\n"
+     "CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES  :table-prefer-style-attributes\n"
+     "CMARK_OPT_FULL_INFO_STRING               :full-info-string\n"
+     "```\n\n"
+     "`exts` is a tuple of keywords that match the name of the extensions "
+     "in the GitHub-Flavored Markdown specification. These extensions are "
+     "currently:\n\n"
+     "- `:autolink`\n"
+     "- `:strikethrough`\n"
+     "- `:table`\n"
+     "- `:tagfilter`\n"
+     "- `:tasklist`"
+    },
+    {"markdown->plaintext", cfun_markdown_to_plaintext,
+     "(markdown->plaintext str &opt opts exts)\n\n"
+     "Convert a string from Markdown to plaintext\n\n"
+     "Markable converts Markdown to plaintext using the cmark-gfm library. "
+     "This is GitHub's implementation of the cmark Common Mark parser. It "
+     "supports the GitHub-Flavored Markdown specification.\n\n"
      "In addition to the string to convert, the user can provide `opts` and "
      "`exts`.\n\n"
      "`opts` is a tuple of keywords. The keywords and the cmark-gfm library "

--- a/test/markable-plaintext.janet
+++ b/test/markable-plaintext.janet
@@ -1,0 +1,64 @@
+(import testament :prefix "" :exit true)
+(import ../build/markable :as markable)
+
+
+(deftest heading
+  (is (= "Heading\n"
+         (markable/markdown->plaintext "# Heading\n"))))
+
+
+(deftest emphasis
+  (is (= "emphasis\n"
+         (markable/markdown->plaintext "*emphasis*\n"))))
+
+
+(deftest block-quote
+  (is (= "block-quote\n"
+         (markable/markdown->plaintext "> block-quote\n"))))
+
+
+(deftest image
+  (is (= "image\n"
+         (markable/markdown->plaintext "![image](image.png)\n"))))
+
+
+(deftest inline-link
+  (is (= "inline-link\n"
+         (markable/markdown->plaintext "[inline-link](doc.html)\n"))))
+
+
+(deftest reference-link
+  (is (= "reference-link\n"
+         (markable/markdown->plaintext (string "[reference-link][id]\n"
+                                               "\n"
+                                               "[id]: doc.html\n")))))
+
+
+(deftest code-span
+  (is (= "code-span\n"
+         (markable/markdown->plaintext "`code-span`\n"))))
+
+
+(deftest code-block
+  (is (= "code-block\n"
+         (markable/markdown->plaintext (string "```\n"
+                                               "code-block\n"
+                                               "```\n")))))
+
+(deftest thematic-break
+  (is (= "Hi\n\nBye\n"
+         (markable/markdown->plaintext (string "Hi\n"
+                                               "---\n"
+                                               "Bye\n")))))
+
+
+(deftest thread-safety
+  (def chan-1 (ev/thread-chan 1))
+  (def chan-2 (ev/thread-chan 1))
+  (ev/do-thread (ev/give chan-1 (markable/markdown->plaintext "**hey**\n")))
+  (ev/do-thread (ev/give chan-2 (markable/markdown->plaintext "# Look!\n")))
+  (is (= "hey\n" (ev/take chan-1)))
+  (is (= "Look!\n" (ev/take chan-2))))
+
+
+(run-tests!)


### PR DESCRIPTION
This PR is an attempt to support conversion to plaintext.

The code is very similar to that which currently exists in [src/markable/converter.c](https://github.com/pyrmont/markable/blob/910272e933baca7586ecab84050bdfd25f05d734/src/markable/converter.c) for `cfun_markdown_to_html`.  

It's a copy-modify job that makes minimal changes to use the upstream function [`cmark_render_plaintext_with_mem`](https://github.com/github/cmark-gfm/blob/587a12bb54d95ac37241377e6ddc93ea0e45439b/src/cmark-gfm.h#L671-L675).

There are some tests included as well.